### PR TITLE
Make plugin compatible with Keycloak

### DIFF
--- a/db/migrate/001_create_oic_sessions.rb
+++ b/db/migrate/001_create_oic_sessions.rb
@@ -2,20 +2,20 @@ class CreateOicSessions < ActiveRecord::Migration
   def self.up
     create_table :oic_sessions do |t|
       t.references :user, foreign_key: true
-      t.string :code
+      t.text :code
       t.string :state
       t.string :nonce
       t.string :session_state
       t.text :id_token
-      t.string :access_token
-      t.string :refresh_token
+      t.text :access_token
+      t.text :refresh_token
       t.datetime :expires_at
       t.timestamps
     end
 
     add_index :oic_sessions, :user_id
-    add_index :oic_sessions, :access_token
-    add_index :oic_sessions, :refresh_token
+    add_index :oic_sessions, :access_token, length: 64
+    add_index :oic_sessions, :refresh_token, length: 64
     add_index :oic_sessions, :id_token, length: 64
   end
   def self.down


### PR DESCRIPTION
Change columns code, access_token and refresh token to text (mysql string type is too small for Keycloak tokens).